### PR TITLE
fix(github-actions): fix code scanning alert - pinned dependencies

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -39,7 +39,7 @@ jobs:
           sparse-checkout: |
             ${{ inputs.path }}
           fetch-depth: 0
-      - uses: xom9ikk/dotenv@v2.2.0
+      - uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68 # v2.2.0
         with:
           path: ${{ inputs.path }}
           load-mode: skip

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -78,7 +78,7 @@ jobs:
       - uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
         with:
           egress-policy: audit
-      - uses: Mattraks/delete-workflow-runs@v2.0.4
+      - uses: Mattraks/delete-workflow-runs@9835e4abbefe04992885a989df6e3f61ddd60117 # v2.0.4
         with:
           retain_days: 30
           keep_minimum_runs: 6


### PR DESCRIPTION
Dependencies have been pinned as proposed by step-security app.