### PR TITLE
feat(infra): add Ansible playbook for TrueNAS SCALE

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: review
+description: Comprehensive code review of a PR or working tree changes. Posts inline comments to PRs; discusses findings conversationally when run locally.
+argument-hint: "[PR number | 'working' | empty for auto-detect]"
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+---
+
+# Code Review Skill
+
+You perform thorough, actionable code reviews.
+Your goal is to catch real problems — not to generate noise.
+
+## Mode Detection
+
+Determine the review target from `$ARGUMENTS`:
+
+- **PR number** (e.g., `42`): Review that GitHub PR. Post findings as a GitHub review with inline comments.
+- **`working`** or empty with uncommitted changes: Review the working tree diff. Discuss findings conversationally with the user.
+- **Empty with clean tree**: Check for an open PR on the current branch. If found, review it. Otherwise, tell the user there's nothing to review.
+
+## Context Gathering
+
+Before reviewing any code, build context so you can distinguish intentional choices from mistakes:
+
+1. Read `CLAUDE.md` for project conventions, architecture, and commit discipline
+2. Read `docs/decisions/README.md` to understand existing ADRs — do not contradict accepted decisions
+3. Read `docs/standards/` for enforceable rules
+4. Check the file types being changed to understand the domain (Terraform, Ansible, markdown, scripts, etc.)
+
+## Gathering the Diff
+
+### PR mode
+
+```bash
+gh pr diff <number>
+gh pr view <number> --json title,body,files,baseRefName,headRefName
+```
+
+### Working tree mode
+
+```bash
+git diff
+git diff --cached
+git status --short
+```
+
+## Review Process
+
+### Step 1: Understand the Change
+
+Before looking for problems, understand what the change does and why:
+
+- Read the PR description or commit messages
+- Identify the intent: new feature, bug fix, refactoring, config change, docs update
+- Note which components are affected
+
+### Step 2: Read Changed Files in Full
+
+Do not review the diff in isolation. For each changed file, read the full file to understand surrounding context.
+Use the `Agent` tool with `subagent_type: Explore` for larger changes spanning many files.
+
+### Step 3: Check Each Category
+
+Review the changes against these categories, ordered by importance.
+Skip categories that don't apply to the change (e.g., skip "Performance" for a docs-only PR).
+
+#### Critical — Must fix before merge
+
+- **Security**: Hardcoded secrets, credentials in plaintext, injection vulnerabilities, overly permissive permissions, missing input validation, sensitive data in logs
+- **Secrets exposure**: Values that should be SOPS-encrypted but aren't, git-crypt patterns not covering new key files, secrets in non-encrypted state
+- **Breaking changes**: Destructive resource changes in Terraform (forces replacement), backwards-incompatible API changes, removed functionality without deprecation
+- **Data loss risk**: Missing backups before destructive operations, unprotected state files, irreversible migrations
+
+#### High — Should fix
+
+- **Bugs and logic errors**: Off-by-one errors, null/empty handling, race conditions, unhandled edge cases, incorrect conditionals
+- **Error handling**: Missing error checks, swallowed errors, unhelpful error messages, missing rollback on failure
+- **IaC state concerns**: Unintended resource destruction (check plan implications), missing lifecycle blocks, state drift risk, missing depends_on
+- **Idempotency** (Ansible): Tasks that aren't idempotent, missing `changed_when`/`failed_when` on command tasks, `no_log: true` missing on sensitive tasks
+
+#### Medium — Recommended
+
+- **Complexity**: Functions doing too many things, deeply nested logic, code that requires extensive comments to understand
+- **Missing tests**: New functionality without tests, changed behavior without updated tests
+- **Documentation gaps**: Public APIs without docs, complex logic without explaining comments, missing ADR for significant decisions
+- **Naming**: Misleading names, inconsistent conventions, abbreviations that harm readability
+
+#### Low — Suggestions
+
+- **Style**: Formatting inconsistencies not caught by linters, minor readability improvements
+- **Performance**: Minor optimizations, unnecessary allocations (only flag if measurably impactful)
+- **Simplification**: Code that could be simpler without changing behavior
+
+### Step 4: IaC-Specific Checks
+
+Apply these when reviewing Terraform, Ansible, or SOPS files:
+
+**Terraform:**
+
+- Variables have descriptions and type constraints
+- Resources follow naming conventions
+- Provider versions are constrained
+- Sensitive values marked with `sensitive = true`
+- No hardcoded values that should be variables
+- Module structure is clean (not mixing concerns)
+
+**Ansible:**
+
+- Tasks have descriptive names
+- Fully qualified collection names (FQCNs) used
+- `no_log: true` on tasks handling passwords, keys, or tokens
+- Command/shell tasks have `changed_when` / `failed_when`
+- Variables follow naming conventions
+
+**SOPS:**
+
+- Values under `secrets` keys are actually ENC[...] blobs
+- `.sops.yaml` creation rules match new file patterns
+- New secret files are covered by encryption
+
+**Markdown:**
+
+- Semantic line breaks (one sentence per line) per ADR-0004
+- Links are valid
+- Tables are properly formatted
+
+### Step 5: Check Commit Discipline
+
+If reviewing a PR with multiple commits:
+
+- Each commit should be one logical change (ADR-0005)
+- Commit messages follow conventional format
+- No "fix typo" or "oops" commits that should be squashed
+- Each commit leaves the repo in a valid state
+
+## Output Format
+
+### PR Mode — Post GitHub Review
+
+Use `gh api` to create a review with inline comments.
+Structure the review body as a summary, then post individual comments on specific lines.
+
+**Review body (summary comment):**
+
+```markdown
+## Review Summary
+
+[1-2 sentence description of what the PR does]
+
+### Findings
+
+[Only list categories that have findings]
+
+**Critical** (N)
+- Brief description of each critical finding
+
+**High** (N)
+- Brief description of each high finding
+
+**Medium** (N)
+- Brief description of each medium finding
+
+[Omit empty categories entirely]
+
+### What's Done Well
+- [Briefly note 1-2 positive aspects, if any stand out — do not force this]
+```
+
+**Inline comments:**
+
+Each comment should include:
+
+- Severity tag: `**[Critical]**`, `**[High]**`, `**[Medium]**`, or `**[Low]**`
+- Category: `Security`, `Bug`, `Error Handling`, `IaC`, `Complexity`, `Style`, etc.
+- Clear description of the issue
+- Why it matters (impact)
+- Suggested fix (code block when possible)
+
+Example:
+
+```text
+**[High]** Error Handling — This `midclt call` task has no `failed_when` condition.
+If the API returns an error, Ansible will report success because the command itself exited 0.
+
+Suggested fix:
+  failed_when: result.rc != 0 or 'error' in result.stderr
+```
+
+**Posting the review:**
+
+```bash
+# Collect all comments into a JSON array, then post as a single review
+gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  -f event=COMMENT \
+  -f body="<summary>" \
+  -f 'comments=[{"path":"file.tf","line":42,"body":"comment text"}]'
+```
+
+Use `COMMENT` event (not `REQUEST_CHANGES` or `APPROVE`) — leave merge decisions to the human.
+
+### Working Tree Mode — Conversational
+
+Present findings directly in the conversation, grouped by severity.
+Use the same category tags and structure, but in markdown.
+After presenting findings, ask the user if they want to fix any of them.
+
+## Behavioral Rules
+
+### Stay Silent When Code is Fine
+
+If the change is clean and well-written, say so briefly and stop.
+Do not invent concerns to appear thorough.
+A review with zero findings is a valid review.
+
+### Limit Noise
+
+- Target ~5 high-signal comments per review, never more than 10
+- Cluster repeated patterns into a single comment (e.g., "These 4 tasks all need `no_log: true`")
+- Do not flag issues that linters already catch (formatting, trailing whitespace)
+- Do not suggest refactoring that isn't related to the change
+
+### Be Actionable
+
+- Every finding must include a suggested fix or clear next step
+- Provide code snippets for fixes when possible
+- Reference specific project standards or ADRs when applicable
+
+### Respect Project Context
+
+- Do not contradict accepted ADRs
+- Do not suggest tools or patterns the project has deliberately avoided
+- Match the project's style — don't impose external conventions
+- Understand that IaC repos have different concerns than application repos
+
+### Do Not Review Generated or Encrypted Content
+
+- Skip SOPS-encrypted values (ENC[...] blobs) — only check that they ARE encrypted
+- Skip lock files (.terraform.lock.hcl) — these are generated
+- Skip state files (terraform.tfstate) — encrypted and managed by OpenTofu
+- Skip git-crypt encrypted files — binary blobs when locked

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -83,13 +83,16 @@ Skip categories that don't apply to the change (e.g., skip "Performance" for a d
 - **Error handling**: Missing error checks, swallowed errors, unhelpful error messages, missing rollback on failure
 - **IaC state concerns**: Unintended resource destruction (check plan implications), missing lifecycle blocks, state drift risk, missing depends_on
 - **Idempotency** (Ansible): Tasks that aren't idempotent, missing `changed_when`/`failed_when` on command tasks, `no_log: true` missing on sensitive tasks
+- **Create vs update mismatch**: Tasks named "create or update" that only create (missing update path), or `changed_when` that doesn't cover all mutable fields (especially secrets — if a password changes but `changed_when` only compares non-secret fields, the update is silently skipped)
+- **Check mode safety**: `ansible.builtin.command`/`shell` tasks execute even with `--check` — if the PR test plan says "run with `--check --diff`", mutating command tasks need `when: not ansible_check_mode` guards
 
 #### Medium — Recommended
 
 - **Complexity**: Functions doing too many things, deeply nested logic, code that requires extensive comments to understand
 - **Missing tests**: New functionality without tests, changed behavior without updated tests
 - **Documentation gaps**: Public APIs without docs, complex logic without explaining comments, missing ADR for significant decisions
-- **Naming**: Misleading names, inconsistent conventions, abbreviations that harm readability
+- **Reference accuracy**: Comments citing ADR numbers, doc links, or external references — verify they point to the correct document (e.g., ADR-0013 vs ADR-0017)
+- **Naming**: Misleading names, inconsistent conventions, abbreviations that harm readability — task/function names must match their actual behavior (e.g., a task named "create or update" that only creates is misleading)
 
 #### Low — Suggestions
 
@@ -112,10 +115,13 @@ Apply these when reviewing Terraform, Ansible, or SOPS files:
 
 **Ansible:**
 
-- Tasks have descriptive names
+- Tasks have descriptive names that match their actual behavior
 - Fully qualified collection names (FQCNs) used
 - `no_log: true` on tasks handling passwords, keys, or tokens
 - Command/shell tasks have `changed_when` / `failed_when`
+- `changed_when` covers ALL fields that could change, including secrets — if a password field is excluded from comparison because you can't read the current value, document why and note the limitation
+- Command/shell tasks that mutate state are guarded with `when: not ansible_check_mode` so `--check` mode doesn't execute real changes
+- Create-only tasks are not named "create or update" — if update logic is missing, the name should say "create" and a comment should note the limitation
 - Variables follow naming conventions
 
 **SOPS:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ The repository manages homelab infrastructure with two tools — see [ADR-0008](
 
 - **OpenTofu** (`terraform/routeros/`) — network device configuration (MikroTik, Horaco switches)
 - **OpenTofu** (`terraform/github/`) — GitHub repository settings ([ADR-0014](docs/decisions/0014-manage-github-repo-settings-with-opentofu.md))
-- **Ansible** (`ansible/`) — TrueNAS SCALE configuration
+- **Ansible** (`ansible/`) — TrueNAS SCALE configuration (see [bootstrap runbook](docs/runbooks/truenas-ansible-bootstrap.md))
 
 ### Secrets
 
@@ -69,6 +69,44 @@ terraform/routeros/
       switch/                          cert + base + switch-bridge
       switch-chip/                     cert + base + switch-chip
 ```
+
+### Ansible structure
+
+```text
+ansible/
+  requirements.yaml                    Collection dependencies (arensb.truenas, community.sops)
+  inventory/
+    hosts.yaml                         TrueNAS host definition
+    host_vars/
+      truenas.home.molier.net/
+        vars.yaml                      Plaintext config (IPs, paths, users, shares)
+        secrets.sops.yaml              SOPS-encrypted credentials (encrypted_regex: "^secrets$")
+  playbooks/
+    truenas.yaml                       Main playbook — includes all task files
+    tasks/
+      system.yaml                        Hostname, timezone, DNS
+      certificates.yaml                  TLS cert from intermediate CA + GUI assignment
+      groups.yaml                        Local groups
+      users.yaml                         Local users
+      datasets.yaml                      ZFS datasets
+      sharing_smb.yaml                   SMB shares
+      sharing_nfs.yaml                   NFS exports
+      nfs.yaml                           NFS service config
+      services.yaml                      Service enable/start
+      scrub.yaml                         ZFS scrub schedules
+      ups.yaml                           UPS/NUT config (midclt)
+      cloud_sync.yaml                    Cloud credentials + sync tasks (midclt)
+      docker.yaml                        Docker pool config (midclt)
+      network.yaml                       Interface IPs, VLANs, MTU (midclt)
+```
+
+Run the playbook:
+
+```bash
+ansible-playbook ansible/playbooks/truenas.yaml -i ansible/inventory/hosts.yaml
+```
+
+Run specific sections with tags: `--tags users`, `--tags shares`, `--tags certificates`, `--tags network`.
 
 ### Per-device apply
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,3 +184,4 @@ Before proposing an approach, check existing ADRs in `docs/decisions/` and stand
 - `/standard [topic|scan]` - Capture an enforceable standard, or scan decisions for missing standards
 - `/runbook [topic|scan]` - Capture an operational runbook, or scan for services/procedures that lack runbooks
 - `/commit` - Analyze working tree changes and create atomic conventional commits
+- `/review [PR#]` - Code review: posts inline comments on a PR, or discusses findings locally for working tree changes

--- a/ansible/inventory/host_vars/truenas.home.molier.net/secrets.sops.yaml
+++ b/ansible/inventory/host_vars/truenas.home.molier.net/secrets.sops.yaml
@@ -1,0 +1,51 @@
+# Secrets for TrueNAS SCALE
+# Encrypt with: sops -e -i ansible/inventory/host_vars/truenas.home.molier.net/secrets.sops.yaml
+# Only keys named "secrets" are encrypted (encrypted_regex: "^secrets$")
+secrets:
+    user_passwords:
+        remko: ENC[AES256_GCM,data:45lc/fxLAfU=,iv:lHzASnLujiHi4Ik5UEVotzb+XrrikqSb+3Hg2L7zHFs=,tag:DpTmbRk5KylSsCUMYxh+Kg==,type:str]
+        daria-karmina: ENC[AES256_GCM,data:eqypainXrmU=,iv:RgEwuJ67DjvAr/bB0PQrkIgR1iHuOIWXV7Sqt69SQ/c=,tag:EYCW9x/6ZM6KE6tMrbcSQw==,type:str]
+    ups_monpwd: ENC[AES256_GCM,data:XFBSKcfDimY=,iv:QxITtI5gdHLNfj5T0dMX9+Hm9tUbMnAnjUBB0pOyRH0=,tag:1mInff5EfYJj2n/HfbEFBg==,type:str]
+    cloud_credentials:
+        BGSchule-Dropbox:
+            token: ENC[AES256_GCM,data:0TZiTmAOJys=,iv:9xiJltS9m19b78ur1SUUWn+HCI80xvZCM6CwEBZ42gQ=,tag:kAoKjBX/RK0rMCu6rxjFfA==,type:str]
+        BGSchule Cloud:
+            url: ENC[AES256_GCM,data:mc3wL29yD7A=,iv:7MKR05v5Y0yp7AGzvRLWR/na7POC/oRXEdhF0suzwfo=,tag:bB+dgOjQW1i3s5CGHOJJ+A==,type:str]
+            user: ENC[AES256_GCM,data:6J1H9g4w85M=,iv:NfbagoUETLEwjOU1h/1bG/cdB/o2VB7Xt55Km0tLarw=,tag:fa4tkwCo31yiLBu7mgKb3A==,type:str]
+            pass: ENC[AES256_GCM,data:VoXSSw2vjKg=,iv:zelZDvasqJyOhzge3fh3gM455t26GU6+ysosMLZII98=,tag:ZXIb2wqe80iI+y0eNo3uyA==,type:str]
+sops:
+    age:
+        - recipient: age12sa9hzgztg0fml5gdznwt7zfz97r98dm7whwjgpxjwryc2sfevzqh2j28y
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwSk5iYjlHU0NhR0hYZmdq
+            bFZsRjlESE5JdERkVSswU1RNZzBKeTJsd1NNCmpDaEJSSjdyV1U1MEVhb25hTHlx
+            cmJsd0R5SGh5M3hhelBLSTNUOTR2TjgKLS0tIHZPc2xRL3pIRVhUei9ReGdGbnoy
+            b2I1SWRZVVBocWcrTy9IOVNLcTNYYVEK09GH0cM7nFkrTfC7GXvB6FGX5J4kMnZF
+            6WDsW5fjR6c1rpH9uCOhOIKomg6GNt6eFKI8txV7KOdCNJyhmRF55g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-06T17:22:53Z"
+    mac: ENC[AES256_GCM,data:IW/n1nNf8YdQCFufeDAwBqoARQhGpNJEQQtO1sDbtbaUJMBG60L+aEMw8nfL3Sk4qU/2tLOF1F81+2apWF86r2y4VoYlS5GbRAeYAV/K9FP3lW5FEGY3l3aIiCPiXWXem/SYkv8WPNda68/htS7BfC0ERHwK0KjnIgcgIO07Mc0=,iv:Qaxet8rArXRy0xHlT+uF+DBp4CVwc7GbAqe5/qFiSRM=,tag:5iES8jlhpkYX31958B/GTQ==,type:str]
+    pgp:
+        - created_at: "2026-04-06T17:22:53Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA12IRFk/1oCEAQ/9EvJnWpDySsYs/x+R7HYR4Y6RCDx8ijIXznkl0e0Anlur
+            XBEwwculS/nRt/Kl1GbfUx2dxVwilozexWGJAjFCURj0tZ+XyfoCjVodwvRMaOUl
+            d5RCeEUlgILOnBuZzezJ8roCJgayz5U71YBI/YfG75XAAOJYEODxIVFsR3lL3hge
+            hfVXOT/+b5QN+/VxKLTyvrWYnX/96n20XQOnhCfsXJ1VMWbi7Sj0I2lPIeJdsUcB
+            bqa8DOQjGfiinMNCMbe2pMdKW4omNhTvnJLycTo2GW3SFt6fitL1i1W1SZtvpn28
+            GQJzKSwJh8vW4cK6Qey+k4dX4MpPfqWWfDcWBuqt5RK/rMem76JzFNtig1y+RGK/
+            NvhqyG3E5YYA6idnbIbnqBjFYX2Id9hhNx3OpLHeJ3r3AyqHpCavTfYFAX5lBbVB
+            x5Y5BAVpQ+RavP+a1P9mBCk2A4lz2hsz5xkyNfYwXg/nzc0UaTxRCutx5nZM+2UW
+            7A2AitYRQNpjeaBJkB8yQpSHp3jExYnnScJSdkDxUqhLvgwf8pt7R7Z4AcqYAZpm
+            vTD13xkYQfO3b37757EOaAYOOO0Xn8Nxs9v9rNiRgcNqXeP+7pQLxIxhlCGC/lgh
+            KJAi/mBn7KrcwwzQ1awvwcJ1E3MkSTcle8gfyBU15z0EttY1DE94fr+gyA2+KNXS
+            XgHh5bcAnZ7tETetnx9gyCLyBkp9j4k/PEuW2XzzmvfQmrJOkr8kIdgDi8VnGhe4
+            4lslsO2vmQDeRjZ1QxYyphGLuaUwdwVVcYW8Gz5Lpi5jfK+u4lOQ/P4QBipNbpg=
+            =5kCP
+            -----END PGP MESSAGE-----
+          fp: 1F476D92728DFC65F15E40464F3984ECAE4A5BAF
+    encrypted_regex: ^secrets$
+    version: 3.12.2

--- a/ansible/inventory/host_vars/truenas.home.molier.net/vars.yaml
+++ b/ansible/inventory/host_vars/truenas.home.molier.net/vars.yaml
@@ -6,9 +6,6 @@ truenas_hostname: truenas
 truenas_domain: home.molier.net
 truenas_timezone: Europe/Berlin
 truenas_nameserver: 172.16.1.1
-truenas_gui_port: 80
-truenas_gui_https_port: 443
-
 # --- Network ---
 truenas_interfaces:
   - name: enp6s0
@@ -150,12 +147,6 @@ truenas_scrub_tasks:
     threshold: 35
 
 # --- Cloud sync ---
-truenas_cloud_credentials:
-  - name: BGSchule-Dropbox
-    provider: DROPBOX
-  - name: BGSchule Cloud
-    provider: WEBDAV
-
 truenas_cloud_sync_tasks:
   - description: "Dropbox - /mnt/attic/backup/bgschule"
     direction: PULL

--- a/ansible/inventory/host_vars/truenas.home.molier.net/vars.yaml
+++ b/ansible/inventory/host_vars/truenas.home.molier.net/vars.yaml
@@ -1,0 +1,201 @@
+# TrueNAS SCALE configuration — plaintext values
+# Secrets are in secrets.sops.yaml (same directory)
+
+# --- System ---
+truenas_hostname: truenas
+truenas_domain: home.molier.net
+truenas_timezone: Europe/Berlin
+truenas_nameserver: 172.16.1.1
+truenas_gui_port: 80
+truenas_gui_https_port: 443
+
+# --- Network ---
+truenas_interfaces:
+  - name: enp6s0
+    address: 172.16.1.2
+    netmask: 24
+    mtu: 9216
+    aliases:
+      - address: 172.16.1.3
+        netmask: 24
+      - address: 172.16.1.4
+        netmask: 24
+  - name: vlan10
+    address: 172.16.10.2
+    netmask: 24
+    mtu: 1500
+
+# --- NFS service ---
+truenas_nfs_bindip: 172.16.1.2
+truenas_nfs_protocols:
+  - NFSV3
+  - NFSV4
+
+# --- Groups ---
+truenas_groups:
+  - name: family
+    gid: 3000
+    smb: true
+
+# --- Users ---
+truenas_users:
+  - name: remko
+    uid: 3000
+    group: family
+    full_name: Remko Molier
+    email: remko@molier.net
+    home: /mnt/storage/personal/remko
+    shell: /usr/bin/zsh
+    smb: true
+    password_disabled: false
+  - name: daria-karmina
+    uid: 3001
+    group: family
+    full_name: Daria-Karmina Iossifova-Molier
+    email: daria-karmina@molier.net
+    home: /mnt/storage/personal/daria-karmina
+    shell: /usr/sbin/nologin
+    smb: true
+    password_disabled: false
+
+# --- ZFS pools (not managed — listed for reference) ---
+# Pools are created manually; Ansible manages datasets within them.
+# - storage (main data)
+# - attic (backups)
+# - nvme (apps/docker)
+# - ssd (fast storage)
+
+# --- Datasets ---
+truenas_datasets:
+  - name: storage/personal
+    comment: Personal home directories
+  - name: storage/personal/remko
+    comment: Remko home
+  - name: storage/personal/daria-karmina
+    comment: Daria-Karmina home
+  - name: storage/shared
+    comment: Family shared data
+  - name: attic/backup
+    comment: Backup root
+  - name: attic/backup/timemachine
+    comment: Time Machine backups
+  - name: attic/backup/bgschule
+    comment: BGSchule Dropbox sync
+
+# --- SMB shares ---
+truenas_smb_shares:
+  - name: personal
+    path: /mnt/storage/personal
+    purpose: PRIVATE_DATASETS_SHARE
+    browsable: true
+    path_suffix: "%U"
+    timemachine: false
+  - name: shared
+    path: /mnt/storage/shared
+    purpose: MULTIPROTOCOL_SHARE
+    browsable: true
+    timemachine: false
+  - name: timemachine
+    path: /mnt/attic/backup/timemachine
+    purpose: TIMEMACHINE_SHARE
+    browsable: true
+    timemachine: true
+    path_suffix: "%U"
+
+# --- NFS shares ---
+truenas_nfs_shares:
+  - path: /mnt/storage/personal
+    enabled: true
+  - path: /mnt/storage/shared
+    maproot_user: root
+    maproot_group: family
+    enabled: true
+
+# --- Services ---
+truenas_services:
+  - name: cifs
+    enabled: true
+    state: started
+  - name: nfs
+    enabled: true
+    state: started
+  - name: ssh
+    enabled: true
+    state: started
+  - name: ups
+    enabled: true
+    state: started
+
+# --- UPS ---
+truenas_ups:
+  mode: MASTER
+  identifier: ups
+  driver: "usbhid-ups$Smart-UPS (USB)"
+  port: auto
+  shutdown: batt
+  shutdowntimer: 30
+  monuser: upsmon
+  powerdown: false
+  hostsync: 15
+
+# --- Scrub tasks ---
+truenas_scrub_tasks:
+  - pool: storage
+    threshold: 35
+  - pool: attic
+    threshold: 35
+  - pool: nvme
+    threshold: 35
+  - pool: ssd
+    threshold: 35
+
+# --- Cloud sync ---
+truenas_cloud_credentials:
+  - name: BGSchule-Dropbox
+    provider: DROPBOX
+  - name: BGSchule Cloud
+    provider: WEBDAV
+
+truenas_cloud_sync_tasks:
+  - description: "Dropbox - /mnt/attic/backup/bgschule"
+    direction: PULL
+    transfer_mode: SYNC
+    path: /mnt/attic/backup/bgschule
+    credential_name: BGSchule-Dropbox
+    attributes:
+      folder: /
+      chunk_size: 96
+    schedule:
+      minute: "0"
+      hour: "*"
+      dom: "*"
+      month: "*"
+      dow: "*"
+    enabled: true
+  - description: "WebDAV - /mnt/attic/backup/bgschule"
+    direction: PUSH
+    transfer_mode: SYNC
+    path: /mnt/attic/backup/bgschule
+    credential_name: BGSchule Cloud
+    attributes:
+      folder: "/BG SCHULE/08_Archiv/Dropbox/bgschule"
+    schedule:
+      minute: "30"
+      hour: "*"
+      dom: "*"
+      month: "*"
+      dow: "*"
+    enabled: true
+
+# --- Docker ---
+truenas_docker:
+  pool: nvme
+  enable_image_updates: true
+  address_pools:
+    - base: "172.17.0.0/12"
+      size: 24
+    - base: "fdd0::/48"
+      size: 64
+
+# --- Certificates ---
+truenas_cert_name: truenas-home-molier-net

--- a/ansible/inventory/host_vars/truenas.home.molier.net/vars.yaml
+++ b/ansible/inventory/host_vars/truenas.home.molier.net/vars.yaml
@@ -146,6 +146,15 @@ truenas_scrub_tasks:
   - pool: ssd
     threshold: 35
 
+# --- Cloud credentials ---
+# Credential attributes (tokens, passwords) are in secrets.sops.yaml
+# under secrets.cloud_credentials.<name>
+truenas_cloud_credentials:
+  - name: BGSchule-Dropbox
+    provider: DROPBOX
+  - name: BGSchule Cloud
+    provider: WEBDAV
+
 # --- Cloud sync ---
 truenas_cloud_sync_tasks:
   - description: "Dropbox - /mnt/attic/backup/bgschule"

--- a/ansible/inventory/hosts.yaml
+++ b/ansible/inventory/hosts.yaml
@@ -4,3 +4,5 @@ all:
       hosts:
         truenas.home.molier.net:
           ansible_host: 172.16.1.2
+          ansible_user: truenas_admin
+          ansible_become: true

--- a/ansible/playbooks/tasks/certificates.yaml
+++ b/ansible/playbooks/tasks/certificates.yaml
@@ -20,11 +20,19 @@
   register: cert_query
   changed_when: false
 
+- name: Get current GUI certificate
+  ansible.builtin.command:
+    cmd: midclt call system.general.config
+  register: gui_current
+  changed_when: false
+
 - name: Set GUI certificate
   ansible.builtin.command:
     cmd: >-
       midclt call system.general.update
       '{"ui_certificate": {{ (cert_query.stdout | from_json)[0].id }}}'
-  when: cert_query.stdout | from_json | length > 0
-  register: gui_cert_result
-  changed_when: gui_cert_result.rc == 0
+  when: >-
+    cert_query.stdout | from_json | length > 0 and
+    (gui_current.stdout | from_json).ui_certificate.id | default(0) !=
+    (cert_query.stdout | from_json)[0].id
+  changed_when: true

--- a/ansible/playbooks/tasks/certificates.yaml
+++ b/ansible/playbooks/tasks/certificates.yaml
@@ -1,0 +1,30 @@
+---
+- name: Import TLS certificate from intermediate CA
+  arensb.truenas.certificate:
+    name: "{{ truenas_cert_name }}"
+    certificate: "{{ lookup('file', pki_cert_path) }}"
+    private_key: "{{ lookup('file', pki_key_path) }}"
+    state: present
+  vars:
+    pki_cert_path: "{{ playbook_dir }}/../../pki/intermediate-ca/issued/{{ truenas_cert_name }}.crt"
+    pki_key_path: "{{ playbook_dir }}/../../pki/intermediate-ca/private/{{ truenas_cert_name }}.key"
+  no_log: true
+  register: cert_result
+
+- name: Get certificate ID for GUI assignment
+  ansible.builtin.command:
+    cmd: >-
+      midclt call certificate.query
+      '[["name", "=", "{{ truenas_cert_name }}"]]'
+      '{"select": ["id"]}'
+  register: cert_query
+  changed_when: false
+
+- name: Set GUI certificate
+  ansible.builtin.command:
+    cmd: >-
+      midclt call system.general.update
+      '{"ui_certificate": {{ (cert_query.stdout | from_json)[0].id }}}'
+  when: cert_query.stdout | from_json | length > 0
+  register: gui_cert_result
+  changed_when: gui_cert_result.rc == 0

--- a/ansible/playbooks/tasks/certificates.yaml
+++ b/ansible/playbooks/tasks/certificates.yaml
@@ -1,4 +1,22 @@
 ---
+- name: Check TLS certificate exists
+  ansible.builtin.stat:
+    path: "{{ pki_cert_path }}"
+  vars:
+    pki_cert_path: "{{ playbook_dir }}/../../pki/intermediate-ca/issued/{{ truenas_cert_name }}.crt"
+  delegate_to: localhost
+  become: false
+  register: cert_file
+
+- name: Fail if TLS certificate has not been issued
+  ansible.builtin.fail:
+    msg: >-
+      Certificate not found at {{ pki_cert_path }}.
+      Issue it first — see docs/runbooks/pki-intermediate-ca.md.
+  vars:
+    pki_cert_path: "{{ playbook_dir }}/../../pki/intermediate-ca/issued/{{ truenas_cert_name }}.crt"
+  when: not cert_file.stat.exists
+
 - name: Import TLS certificate from intermediate CA
   arensb.truenas.certificate:
     name: "{{ truenas_cert_name }}"

--- a/ansible/playbooks/tasks/certificates.yaml
+++ b/ansible/playbooks/tasks/certificates.yaml
@@ -52,6 +52,7 @@
       midclt call system.general.update
       '{"ui_certificate": {{ (cert_query.stdout | from_json)[0].id }}}'
   when: >-
+    not ansible_check_mode and
     cert_query.stdout | from_json | length > 0 and
     (gui_current.stdout | from_json).ui_certificate.id | default(0) !=
     (cert_query.stdout | from_json)[0].id

--- a/ansible/playbooks/tasks/certificates.yaml
+++ b/ansible/playbooks/tasks/certificates.yaml
@@ -1,21 +1,23 @@
 ---
-- name: Check TLS certificate exists
+- name: Check TLS certificate and key exist
   ansible.builtin.stat:
-    path: "{{ pki_cert_path }}"
-  vars:
-    pki_cert_path: "{{ playbook_dir }}/../../pki/intermediate-ca/issued/{{ truenas_cert_name }}.crt"
+    path: "{{ item }}"
+  loop:
+    - "{{ playbook_dir }}/../../pki/intermediate-ca/issued/{{ truenas_cert_name }}.crt"
+    - "{{ playbook_dir }}/../../pki/intermediate-ca/private/{{ truenas_cert_name }}.key"
   delegate_to: localhost
   become: false
-  register: cert_file
+  register: pki_files
 
-- name: Fail if TLS certificate has not been issued
+- name: Fail if TLS certificate or key is missing
   ansible.builtin.fail:
     msg: >-
-      Certificate not found at {{ pki_cert_path }}.
-      Issue it first — see docs/runbooks/pki-intermediate-ca.md.
-  vars:
-    pki_cert_path: "{{ playbook_dir }}/../../pki/intermediate-ca/issued/{{ truenas_cert_name }}.crt"
-  when: not cert_file.stat.exists
+      PKI file not found at {{ item.item }}.
+      Issue the certificate first — see docs/runbooks/pki-operations.md.
+  loop: "{{ pki_files.results }}"
+  loop_control:
+    label: "{{ item.item | basename }}"
+  when: not item.stat.exists
 
 - name: Import TLS certificate from intermediate CA
   arensb.truenas.certificate:

--- a/ansible/playbooks/tasks/certificates.yaml
+++ b/ansible/playbooks/tasks/certificates.yaml
@@ -59,4 +59,6 @@
     desired_cert_id | int != 0 and
     (gui_current.stdout | from_json).ui_certificate.id | default(0) | int !=
     desired_cert_id | int
+  register: gui_cert_result
   changed_when: true
+  failed_when: gui_cert_result.rc != 0 or 'error' in (gui_cert_result.stderr | default(''))

--- a/ansible/playbooks/tasks/certificates.yaml
+++ b/ansible/playbooks/tasks/certificates.yaml
@@ -50,10 +50,13 @@
   ansible.builtin.command:
     cmd: >-
       midclt call system.general.update
-      '{"ui_certificate": {{ (cert_query.stdout | from_json)[0].id }}}'
+      '{"ui_certificate": {{ desired_cert_id }}}'
+  vars:
+    desired_cert: "{{ (cert_query.stdout | from_json | first) | default({}) }}"
+    desired_cert_id: "{{ desired_cert.id | default(0) }}"
   when: >-
     not ansible_check_mode and
-    cert_query.stdout | from_json | length > 0 and
-    (gui_current.stdout | from_json).ui_certificate.id | default(0) !=
-    (cert_query.stdout | from_json)[0].id
+    desired_cert_id | int != 0 and
+    (gui_current.stdout | from_json).ui_certificate.id | default(0) | int !=
+    desired_cert_id | int
   changed_when: true

--- a/ansible/playbooks/tasks/cloud_sync.yaml
+++ b/ansible/playbooks/tasks/cloud_sync.yaml
@@ -1,0 +1,86 @@
+---
+# Cloud sync is not covered by arensb.truenas — use midclt (ADR-0013)
+
+# --- Cloud credentials ---
+
+- name: Query existing cloud credentials
+  ansible.builtin.command:
+    cmd: midclt call cloudsync.credentials.query
+  register: cloud_creds_current
+  changed_when: false
+
+- name: Create or update Dropbox credential
+  ansible.builtin.command:
+    cmd: >-
+      midclt call cloudsync.credentials.create
+      '{{ cred_payload | to_json }}'
+  vars:
+    cred_payload:
+      name: BGSchule-Dropbox
+      provider: DROPBOX
+      attributes:
+        token: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule-Dropbox'].token }}"
+  when: >-
+    cloud_creds_current.stdout | from_json
+    | selectattr('name', 'equalto', 'BGSchule-Dropbox')
+    | list | length == 0
+  no_log: true
+
+- name: Create or update WebDAV credential
+  ansible.builtin.command:
+    cmd: >-
+      midclt call cloudsync.credentials.create
+      '{{ cred_payload | to_json }}'
+  vars:
+    cred_payload:
+      name: BGSchule Cloud
+      provider: WEBDAV
+      attributes:
+        url: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule Cloud'].url }}"
+        user: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule Cloud'].user }}"
+        pass: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule Cloud'].pass }}"
+  when: >-
+    cloud_creds_current.stdout | from_json
+    | selectattr('name', 'equalto', 'BGSchule Cloud')
+    | list | length == 0
+  no_log: true
+
+# --- Cloud sync tasks ---
+
+- name: Query existing cloud sync tasks
+  ansible.builtin.command:
+    cmd: midclt call cloudsync.query
+  register: cloud_sync_current
+  changed_when: false
+
+- name: Create cloud sync tasks
+  ansible.builtin.command:
+    cmd: >-
+      midclt call cloudsync.create
+      '{{ sync_payload | to_json }}'
+  vars:
+    cred_id: >-
+      {{ cloud_creds_current.stdout | from_json
+         | selectattr('name', 'equalto', item.credential_name)
+         | map(attribute='id') | first }}
+    sync_payload:
+      description: "{{ item.description }}"
+      direction: "{{ item.direction }}"
+      transfer_mode: "{{ item.transfer_mode }}"
+      path: "{{ item.path }}"
+      credentials: "{{ cred_id | int }}"
+      attributes: "{{ item.attributes }}"
+      schedule:
+        minute: "{{ item.schedule.minute }}"
+        hour: "{{ item.schedule.hour }}"
+        dom: "{{ item.schedule.dom }}"
+        month: "{{ item.schedule.month }}"
+        dow: "{{ item.schedule.dow }}"
+      enabled: "{{ item.enabled }}"
+  loop: "{{ truenas_cloud_sync_tasks }}"
+  loop_control:
+    label: "{{ item.description }}"
+  when: >-
+    cloud_sync_current.stdout | from_json
+    | selectattr('description', 'equalto', item.description)
+    | list | length == 0

--- a/ansible/playbooks/tasks/cloud_sync.yaml
+++ b/ansible/playbooks/tasks/cloud_sync.yaml
@@ -82,6 +82,7 @@
   loop_control:
     label: "{{ item.credential_name }}"
   when: >-
+    not ansible_check_mode and
     cloud_creds_current.stdout | from_json
     | selectattr('name', 'equalto', item.credential_name)
     | list | length == 0

--- a/ansible/playbooks/tasks/cloud_sync.yaml
+++ b/ansible/playbooks/tasks/cloud_sync.yaml
@@ -13,46 +13,26 @@
   changed_when: false
   no_log: true
 
-- name: Create Dropbox credential
+- name: Create cloud credential
   ansible.builtin.command:
     cmd: >-
       midclt call cloudsync.credentials.create
       '{{ cred_payload | to_json }}'
   vars:
     cred_payload:
-      name: BGSchule-Dropbox
-      provider: DROPBOX
-      attributes:
-        token: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule-Dropbox'].token }}"
+      name: "{{ item.name }}"
+      provider: "{{ item.provider }}"
+      attributes: "{{ truenas_secrets.secrets.cloud_credentials[item.name] }}"
+  loop: "{{ truenas_cloud_credentials }}"
+  loop_control:
+    label: "{{ item.name }}"
   when: >-
     not ansible_check_mode and
     cloud_creds_current.stdout | from_json
-    | selectattr('name', 'equalto', 'BGSchule-Dropbox')
+    | selectattr('name', 'equalto', item.name)
     | list | length == 0
   no_log: true
-  register: dropbox_cred_created
-  changed_when: true
-
-- name: Create WebDAV credential
-  ansible.builtin.command:
-    cmd: >-
-      midclt call cloudsync.credentials.create
-      '{{ cred_payload | to_json }}'
-  vars:
-    cred_payload:
-      name: BGSchule Cloud
-      provider: WEBDAV
-      attributes:
-        url: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule Cloud'].url }}"
-        user: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule Cloud'].user }}"
-        pass: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule Cloud'].pass }}"
-  when: >-
-    not ansible_check_mode and
-    cloud_creds_current.stdout | from_json
-    | selectattr('name', 'equalto', 'BGSchule Cloud')
-    | list | length == 0
-  no_log: true
-  register: webdav_cred_created
+  register: cloud_creds_created
   changed_when: true
 
 - name: Refresh cloud credentials after creates
@@ -61,7 +41,7 @@
   register: cloud_creds_current
   changed_when: false
   no_log: true
-  when: dropbox_cred_created is changed or webdav_cred_created is changed
+  when: cloud_creds_created is changed
 
 # --- Cloud sync tasks ---
 # Note: These tasks only create missing sync tasks. Updates to existing

--- a/ansible/playbooks/tasks/cloud_sync.yaml
+++ b/ansible/playbooks/tasks/cloud_sync.yaml
@@ -34,6 +34,7 @@
   no_log: true
   register: cloud_creds_created
   changed_when: true
+  failed_when: cloud_creds_created.rc != 0
 
 - name: Refresh cloud credentials after creates
   ansible.builtin.command:
@@ -99,4 +100,6 @@
     cloud_sync_current.stdout | from_json
     | selectattr('description', 'equalto', item.description)
     | list | length == 0
+  register: cloud_sync_created
   changed_when: true
+  failed_when: cloud_sync_created.rc != 0

--- a/ansible/playbooks/tasks/cloud_sync.yaml
+++ b/ansible/playbooks/tasks/cloud_sync.yaml
@@ -8,6 +8,7 @@
     cmd: midclt call cloudsync.credentials.query
   register: cloud_creds_current
   changed_when: false
+  no_log: true
 
 - name: Create or update Dropbox credential
   ansible.builtin.command:
@@ -25,6 +26,7 @@
     | selectattr('name', 'equalto', 'BGSchule-Dropbox')
     | list | length == 0
   no_log: true
+  register: dropbox_cred_created
 
 - name: Create or update WebDAV credential
   ansible.builtin.command:
@@ -44,6 +46,15 @@
     | selectattr('name', 'equalto', 'BGSchule Cloud')
     | list | length == 0
   no_log: true
+  register: webdav_cred_created
+
+- name: Refresh cloud credentials after creates
+  ansible.builtin.command:
+    cmd: midclt call cloudsync.credentials.query
+  register: cloud_creds_current
+  changed_when: false
+  no_log: true
+  when: dropbox_cred_created is changed or webdav_cred_created is changed
 
 # --- Cloud sync tasks ---
 

--- a/ansible/playbooks/tasks/cloud_sync.yaml
+++ b/ansible/playbooks/tasks/cloud_sync.yaml
@@ -1,7 +1,10 @@
 ---
-# Cloud sync is not covered by arensb.truenas — use midclt (ADR-0013)
+# Cloud sync is not covered by arensb.truenas — use midclt (ADR-0017)
 
 # --- Cloud credentials ---
+# Note: These tasks only create missing credentials. Credential attribute
+# updates (token rotation, URL changes) require manual deletion and re-creation
+# via midclt or the TrueNAS UI, then re-running this playbook.
 
 - name: Query existing cloud credentials
   ansible.builtin.command:
@@ -10,7 +13,7 @@
   changed_when: false
   no_log: true
 
-- name: Create or update Dropbox credential
+- name: Create Dropbox credential
   ansible.builtin.command:
     cmd: >-
       midclt call cloudsync.credentials.create
@@ -29,7 +32,7 @@
   register: dropbox_cred_created
   changed_when: true
 
-- name: Create or update WebDAV credential
+- name: Create WebDAV credential
   ansible.builtin.command:
     cmd: >-
       midclt call cloudsync.credentials.create
@@ -59,12 +62,27 @@
   when: dropbox_cred_created is changed or webdav_cred_created is changed
 
 # --- Cloud sync tasks ---
+# Note: These tasks only create missing sync tasks. Updates to existing
+# sync task configuration require manual changes via midclt or the TrueNAS UI.
 
 - name: Query existing cloud sync tasks
   ansible.builtin.command:
     cmd: midclt call cloudsync.query
   register: cloud_sync_current
   changed_when: false
+
+- name: Verify credential exists before creating sync task
+  ansible.builtin.fail:
+    msg: >-
+      Credential '{{ item.credential_name }}' not found.
+      Create it first or check the credential name in vars.yaml.
+  loop: "{{ truenas_cloud_sync_tasks }}"
+  loop_control:
+    label: "{{ item.credential_name }}"
+  when: >-
+    cloud_creds_current.stdout | from_json
+    | selectattr('name', 'equalto', item.credential_name)
+    | list | length == 0
 
 - name: Create cloud sync tasks
   ansible.builtin.command:
@@ -75,7 +93,7 @@
     cred_id: >-
       {{ cloud_creds_current.stdout | from_json
          | selectattr('name', 'equalto', item.credential_name)
-         | map(attribute='id') | first | default(none) }}
+         | map(attribute='id') | first }}
     sync_payload:
       description: "{{ item.description }}"
       direction: "{{ item.direction }}"
@@ -97,5 +115,4 @@
     cloud_sync_current.stdout | from_json
     | selectattr('description', 'equalto', item.description)
     | list | length == 0
-  failed_when: cred_id is none
   changed_when: true

--- a/ansible/playbooks/tasks/cloud_sync.yaml
+++ b/ansible/playbooks/tasks/cloud_sync.yaml
@@ -25,6 +25,7 @@
       attributes:
         token: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule-Dropbox'].token }}"
   when: >-
+    not ansible_check_mode and
     cloud_creds_current.stdout | from_json
     | selectattr('name', 'equalto', 'BGSchule-Dropbox')
     | list | length == 0
@@ -46,6 +47,7 @@
         user: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule Cloud'].user }}"
         pass: "{{ truenas_secrets.secrets.cloud_credentials['BGSchule Cloud'].pass }}"
   when: >-
+    not ansible_check_mode and
     cloud_creds_current.stdout | from_json
     | selectattr('name', 'equalto', 'BGSchule Cloud')
     | list | length == 0
@@ -112,6 +114,7 @@
   loop_control:
     label: "{{ item.description }}"
   when: >-
+    not ansible_check_mode and
     cloud_sync_current.stdout | from_json
     | selectattr('description', 'equalto', item.description)
     | list | length == 0

--- a/ansible/playbooks/tasks/cloud_sync.yaml
+++ b/ansible/playbooks/tasks/cloud_sync.yaml
@@ -27,6 +27,7 @@
     | list | length == 0
   no_log: true
   register: dropbox_cred_created
+  changed_when: true
 
 - name: Create or update WebDAV credential
   ansible.builtin.command:
@@ -47,6 +48,7 @@
     | list | length == 0
   no_log: true
   register: webdav_cred_created
+  changed_when: true
 
 - name: Refresh cloud credentials after creates
   ansible.builtin.command:
@@ -73,7 +75,7 @@
     cred_id: >-
       {{ cloud_creds_current.stdout | from_json
          | selectattr('name', 'equalto', item.credential_name)
-         | map(attribute='id') | first }}
+         | map(attribute='id') | first | default(none) }}
     sync_payload:
       description: "{{ item.description }}"
       direction: "{{ item.direction }}"
@@ -95,3 +97,5 @@
     cloud_sync_current.stdout | from_json
     | selectattr('description', 'equalto', item.description)
     | list | length == 0
+  failed_when: cred_id is none
+  changed_when: true

--- a/ansible/playbooks/tasks/datasets.yaml
+++ b/ansible/playbooks/tasks/datasets.yaml
@@ -1,0 +1,10 @@
+---
+- name: Manage ZFS datasets
+  arensb.truenas.filesystem:
+    name: "{{ item.name }}"
+    type: FILESYSTEM
+    comment: "{{ item.comment | default(omit) }}"
+    state: present
+  loop: "{{ truenas_datasets }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/ansible/playbooks/tasks/docker.yaml
+++ b/ansible/playbooks/tasks/docker.yaml
@@ -1,0 +1,22 @@
+---
+# Docker config is not covered by arensb.truenas — use midclt (ADR-0013)
+
+- name: Get current Docker configuration
+  ansible.builtin.command:
+    cmd: midclt call docker.config
+  register: docker_current
+  changed_when: false
+
+- name: Configure Docker
+  ansible.builtin.command:
+    cmd: >-
+      midclt call docker.update
+      '{{ docker_payload | to_json }}'
+  vars:
+    docker_payload:
+      pool: "{{ truenas_docker.pool }}"
+      enable_image_updates: "{{ truenas_docker.enable_image_updates }}"
+      address_pools: "{{ truenas_docker.address_pools }}"
+  when: (docker_current.stdout | from_json).pool != truenas_docker.pool
+  register: docker_result
+  changed_when: docker_result.rc == 0

--- a/ansible/playbooks/tasks/docker.yaml
+++ b/ansible/playbooks/tasks/docker.yaml
@@ -13,10 +13,15 @@
       midclt call docker.update
       '{{ docker_payload | to_json }}'
   vars:
+    current: "{{ docker_current.stdout | from_json }}"
     docker_payload:
       pool: "{{ truenas_docker.pool }}"
       enable_image_updates: "{{ truenas_docker.enable_image_updates }}"
       address_pools: "{{ truenas_docker.address_pools }}"
-  when: (docker_current.stdout | from_json).pool != truenas_docker.pool
+  when: >-
+    current.pool != truenas_docker.pool or
+    current.enable_image_updates != truenas_docker.enable_image_updates or
+    current.address_pools | default([]) | sort(attribute='base') !=
+    truenas_docker.address_pools | sort(attribute='base')
   register: docker_result
-  changed_when: docker_result.rc == 0
+  changed_when: true

--- a/ansible/playbooks/tasks/docker.yaml
+++ b/ansible/playbooks/tasks/docker.yaml
@@ -27,3 +27,4 @@
     )
   register: docker_result
   changed_when: true
+  failed_when: docker_result.rc != 0 or 'error' in (docker_result.stderr | default(''))

--- a/ansible/playbooks/tasks/docker.yaml
+++ b/ansible/playbooks/tasks/docker.yaml
@@ -1,5 +1,5 @@
 ---
-# Docker config is not covered by arensb.truenas — use midclt (ADR-0013)
+# Docker config is not covered by arensb.truenas — use midclt (ADR-0017)
 
 - name: Get current Docker configuration
   ansible.builtin.command:

--- a/ansible/playbooks/tasks/docker.yaml
+++ b/ansible/playbooks/tasks/docker.yaml
@@ -19,9 +19,11 @@
       enable_image_updates: "{{ truenas_docker.enable_image_updates }}"
       address_pools: "{{ truenas_docker.address_pools }}"
   when: >-
-    current.pool != truenas_docker.pool or
-    current.enable_image_updates != truenas_docker.enable_image_updates or
-    current.address_pools | default([]) | sort(attribute='base') !=
-    truenas_docker.address_pools | sort(attribute='base')
+    not ansible_check_mode and (
+      current.pool != truenas_docker.pool or
+      current.enable_image_updates != truenas_docker.enable_image_updates or
+      current.address_pools | default([]) | sort(attribute='base') !=
+      truenas_docker.address_pools | sort(attribute='base')
+    )
   register: docker_result
   changed_when: true

--- a/ansible/playbooks/tasks/groups.yaml
+++ b/ansible/playbooks/tasks/groups.yaml
@@ -1,0 +1,10 @@
+---
+- name: Manage groups
+  arensb.truenas.group:
+    name: "{{ item.name }}"
+    gid: "{{ item.gid }}"
+    smb: "{{ item.smb | default(false) }}"
+    state: present
+  loop: "{{ truenas_groups }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/ansible/playbooks/tasks/network.yaml
+++ b/ansible/playbooks/tasks/network.yaml
@@ -1,5 +1,5 @@
 ---
-# Network config is not covered by arensb.truenas — use midclt (ADR-0013)
+# Network config is not covered by arensb.truenas — use midclt (ADR-0017)
 #
 # WARNING: Changing network settings can lock out SSH access.
 # Always have console access ready before applying network changes.
@@ -37,10 +37,11 @@
   loop: "{{ truenas_interfaces }}"
   loop_control:
     label: "{{ item.name }}"
-  register: network_result
-  changed_when: >-
+  when: >-
     (current_iface.mtu | default(0)) | int != item.mtu | int or
     current_addresses != desired_addresses
+  register: network_result
+  changed_when: true
 
 - name: Commit network changes
   ansible.builtin.command:

--- a/ansible/playbooks/tasks/network.yaml
+++ b/ansible/playbooks/tasks/network.yaml
@@ -1,0 +1,42 @@
+---
+# Network config is not covered by arensb.truenas — use midclt (ADR-0013)
+#
+# WARNING: Changing network settings can lock out SSH access.
+# Always have console access ready before applying network changes.
+# Run with --tags network separately and verify connectivity after each change.
+
+- name: Get current network interfaces
+  ansible.builtin.command:
+    cmd: midclt call interface.query
+  register: network_current
+  changed_when: false
+
+- name: Configure network interfaces
+  ansible.builtin.command:
+    cmd: >-
+      midclt call interface.update
+      '{{ item.name }}'
+      '{{ iface_payload | to_json }}'
+  vars:
+    iface_payload:
+      ipv4_dhcp: false
+      aliases: >-
+        {{ [{"address": item.address, "netmask": item.netmask}]
+           + (item.aliases | default([])) }}
+      mtu: "{{ item.mtu }}"
+  loop: "{{ truenas_interfaces }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: network_result
+  changed_when: network_result.rc == 0
+
+- name: Commit network changes
+  ansible.builtin.command:
+    cmd: midclt call interface.commit '{"checkin_timeout": 60}'
+  when: network_result is changed
+  register: network_commit
+
+- name: Check in network changes (confirm connectivity)
+  ansible.builtin.command:
+    cmd: midclt call interface.checkin
+  when: network_commit is changed

--- a/ansible/playbooks/tasks/network.yaml
+++ b/ansible/playbooks/tasks/network.yaml
@@ -18,25 +18,39 @@
       '{{ item.name }}'
       '{{ iface_payload | to_json }}'
   vars:
+    current_iface: >-
+      {{ network_current.stdout | from_json
+         | selectattr('name', 'equalto', item.name)
+         | first | default({}) }}
+    desired_aliases: >-
+      {{ [{"address": item.address, "netmask": item.netmask}]
+         + (item.aliases | default([])) }}
+    current_aliases: >-
+      {{ current_iface.get('aliases', [])
+         | map(attribute='address')
+         | list
+         | default([]) }}
     iface_payload:
       ipv4_dhcp: false
-      aliases: >-
-        {{ [{"address": item.address, "netmask": item.netmask}]
-           + (item.aliases | default([])) }}
+      aliases: "{{ desired_aliases }}"
       mtu: "{{ item.mtu }}"
   loop: "{{ truenas_interfaces }}"
   loop_control:
     label: "{{ item.name }}"
   register: network_result
-  changed_when: network_result.rc == 0
+  changed_when: >-
+    current_iface.get('mtu', 0) | int != item.mtu | int or
+    current_aliases | sort != desired_aliases | map(attribute='address') | list | sort
 
 - name: Commit network changes
   ansible.builtin.command:
     cmd: midclt call interface.commit '{"checkin_timeout": 60}'
   when: network_result is changed
   register: network_commit
+  changed_when: true
 
 - name: Check in network changes (confirm connectivity)
   ansible.builtin.command:
     cmd: midclt call interface.checkin
   when: network_commit is changed
+  changed_when: true

--- a/ansible/playbooks/tasks/network.yaml
+++ b/ansible/playbooks/tasks/network.yaml
@@ -25,11 +25,11 @@
     desired_aliases: >-
       {{ [{"address": item.address, "netmask": item.netmask}]
          + (item.aliases | default([])) }}
-    current_aliases: >-
-      {{ current_iface.get('aliases', [])
-         | map(attribute='address')
-         | list
-         | default([]) }}
+    desired_addresses: >-
+      {{ desired_aliases | map(attribute='address') | list | sort }}
+    current_addresses: >-
+      {{ (current_iface.aliases | default([]))
+         | map(attribute='address') | list | sort }}
     iface_payload:
       ipv4_dhcp: false
       aliases: "{{ desired_aliases }}"
@@ -39,8 +39,8 @@
     label: "{{ item.name }}"
   register: network_result
   changed_when: >-
-    current_iface.get('mtu', 0) | int != item.mtu | int or
-    current_aliases | sort != desired_aliases | map(attribute='address') | list | sort
+    (current_iface.mtu | default(0)) | int != item.mtu | int or
+    current_addresses != desired_addresses
 
 - name: Commit network changes
   ansible.builtin.command:

--- a/ansible/playbooks/tasks/network.yaml
+++ b/ansible/playbooks/tasks/network.yaml
@@ -59,10 +59,26 @@
   register: network_commit
   changed_when: true
 
-- name: Check in network changes (confirm connectivity)
+- name: Wait for SSH connectivity after network changes
+  ansible.builtin.wait_for:
+    host: "{{ ansible_host | default(inventory_hostname) }}"
+    port: "{{ ansible_port | default(22) }}"
+    timeout: 30
+    delay: 5
+    state: started
+  delegate_to: localhost
+  become: false
+  when:
+    - not ansible_check_mode
+    - network_commit is changed
+  register: network_ssh_check
+  changed_when: false
+
+- name: Check in network changes after connectivity confirmed
   ansible.builtin.command:
     cmd: midclt call interface.checkin
   when:
     - not ansible_check_mode
     - network_commit is changed
+    - network_ssh_check is succeeded
   changed_when: true

--- a/ansible/playbooks/tasks/network.yaml
+++ b/ansible/playbooks/tasks/network.yaml
@@ -25,11 +25,15 @@
     desired_aliases: >-
       {{ [{"address": item.address, "netmask": item.netmask}]
          + (item.aliases | default([])) }}
-    desired_addresses: >-
-      {{ desired_aliases | map(attribute='address') | list | sort }}
-    current_addresses: >-
+    desired_tuples: >-
+      {{ desired_aliases | map('dict2items')
+         | map('selectattr', 'key', 'in', ['address', 'netmask'])
+         | map('items2dict') | list | sort(attribute='address') }}
+    current_tuples: >-
       {{ (current_iface.aliases | default([]))
-         | map(attribute='address') | list | sort }}
+         | map('dict2items')
+         | map('selectattr', 'key', 'in', ['address', 'netmask'])
+         | map('items2dict') | list | sort(attribute='address') }}
     iface_payload:
       ipv4_dhcp: false
       aliases: "{{ desired_aliases }}"
@@ -38,20 +42,27 @@
   loop_control:
     label: "{{ item.name }}"
   when: >-
-    (current_iface.mtu | default(0)) | int != item.mtu | int or
-    current_addresses != desired_addresses
+    not ansible_check_mode and (
+      (current_iface.mtu | default(0)) | int != item.mtu | int or
+      (current_iface.ipv4_dhcp | default(false)) != false or
+      current_tuples != desired_tuples
+    )
   register: network_result
   changed_when: true
 
 - name: Commit network changes
   ansible.builtin.command:
     cmd: midclt call interface.commit '{"checkin_timeout": 60}'
-  when: network_result is changed
+  when:
+    - not ansible_check_mode
+    - network_result is changed
   register: network_commit
   changed_when: true
 
 - name: Check in network changes (confirm connectivity)
   ansible.builtin.command:
     cmd: midclt call interface.checkin
-  when: network_commit is changed
+  when:
+    - not ansible_check_mode
+    - network_commit is changed
   changed_when: true

--- a/ansible/playbooks/tasks/network.yaml
+++ b/ansible/playbooks/tasks/network.yaml
@@ -49,6 +49,7 @@
     )
   register: network_result
   changed_when: true
+  failed_when: network_result.rc != 0 or 'error' in (network_result.stderr | default(''))
 
 - name: Commit network changes
   ansible.builtin.command:
@@ -58,6 +59,7 @@
     - network_result is changed
   register: network_commit
   changed_when: true
+  failed_when: network_commit.rc != 0 or 'error' in (network_commit.stderr | default(''))
 
 - name: Wait for SSH connectivity after network changes
   ansible.builtin.wait_for:
@@ -81,4 +83,6 @@
     - not ansible_check_mode
     - network_commit is changed
     - network_ssh_check is succeeded
+  register: network_checkin
   changed_when: true
+  failed_when: network_checkin.rc != 0 or 'error' in (network_checkin.stderr | default(''))

--- a/ansible/playbooks/tasks/nfs.yaml
+++ b/ansible/playbooks/tasks/nfs.yaml
@@ -1,0 +1,5 @@
+---
+- name: Configure NFS service
+  arensb.truenas.nfs:
+    protocols: "{{ truenas_nfs_protocols }}"
+    bindip: "{{ truenas_nfs_bindip }}"

--- a/ansible/playbooks/tasks/scrub.yaml
+++ b/ansible/playbooks/tasks/scrub.yaml
@@ -1,0 +1,10 @@
+---
+- name: Manage scrub tasks
+  arensb.truenas.pool_scrub_task:
+    pool: "{{ item.pool }}"
+    threshold: "{{ item.threshold }}"
+    enabled: true
+    state: present
+  loop: "{{ truenas_scrub_tasks }}"
+  loop_control:
+    label: "{{ item.pool }}"

--- a/ansible/playbooks/tasks/services.yaml
+++ b/ansible/playbooks/tasks/services.yaml
@@ -1,0 +1,9 @@
+---
+- name: Manage services
+  arensb.truenas.service:
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    state: "{{ item.state }}"
+  loop: "{{ truenas_services }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/ansible/playbooks/tasks/sharing_nfs.yaml
+++ b/ansible/playbooks/tasks/sharing_nfs.yaml
@@ -1,0 +1,11 @@
+---
+- name: Manage NFS shares
+  arensb.truenas.sharing_nfs:
+    path: "{{ item.path }}"
+    maproot_user: "{{ item.maproot_user | default(omit) }}"
+    maproot_group: "{{ item.maproot_group | default(omit) }}"
+    enabled: "{{ item.enabled | default(true) }}"
+    state: present
+  loop: "{{ truenas_nfs_shares }}"
+  loop_control:
+    label: "{{ item.path }}"

--- a/ansible/playbooks/tasks/sharing_smb.yaml
+++ b/ansible/playbooks/tasks/sharing_smb.yaml
@@ -1,0 +1,13 @@
+---
+- name: Manage SMB shares
+  arensb.truenas.sharing_smb:
+    name: "{{ item.name }}"
+    path: "{{ item.path }}"
+    purpose: "{{ item.purpose | default(omit) }}"
+    browsable: "{{ item.browsable | default(true) }}"
+    timemachine: "{{ item.timemachine | default(false) }}"
+    path_suffix: "{{ item.path_suffix | default(omit) }}"
+    state: present
+  loop: "{{ truenas_smb_shares }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/ansible/playbooks/tasks/system.yaml
+++ b/ansible/playbooks/tasks/system.yaml
@@ -1,0 +1,29 @@
+---
+- name: Set hostname
+  arensb.truenas.hostname:
+    name: "{{ truenas_hostname }}"
+
+- name: Configure system general settings
+  ansible.builtin.command:
+    cmd: >-
+      midclt call system.general.update
+      '{{ system_general_payload | to_json }}'
+  vars:
+    system_general_payload:
+      timezone: "{{ truenas_timezone }}"
+      ui_httpsredirect: true
+  register: system_general_result
+  changed_when: system_general_result.rc == 0
+
+- name: Configure DNS
+  ansible.builtin.command:
+    cmd: >-
+      midclt call network.configuration.update
+      '{{ dns_payload | to_json }}'
+  vars:
+    dns_payload:
+      hostname: "{{ truenas_hostname }}"
+      domain: "{{ truenas_domain }}"
+      nameserver1: "{{ truenas_nameserver }}"
+  register: dns_result
+  changed_when: dns_result.rc == 0

--- a/ansible/playbooks/tasks/system.yaml
+++ b/ansible/playbooks/tasks/system.yaml
@@ -20,8 +20,10 @@
       timezone: "{{ truenas_timezone }}"
       ui_httpsredirect: true
   when: >-
-    current.timezone != truenas_timezone or
-    current.ui_httpsredirect != true
+    not ansible_check_mode and (
+      current.timezone != truenas_timezone or
+      current.ui_httpsredirect != true
+    )
   changed_when: true
 
 - name: Get current DNS configuration
@@ -42,7 +44,9 @@
       domain: "{{ truenas_domain }}"
       nameserver1: "{{ truenas_nameserver }}"
   when: >-
-    current.hostname != truenas_hostname or
-    current.domain != truenas_domain or
-    current.nameserver1 != truenas_nameserver
+    not ansible_check_mode and (
+      current.hostname != truenas_hostname or
+      current.domain != truenas_domain or
+      current.nameserver1 != truenas_nameserver
+    )
   changed_when: true

--- a/ansible/playbooks/tasks/system.yaml
+++ b/ansible/playbooks/tasks/system.yaml
@@ -3,17 +3,32 @@
   arensb.truenas.hostname:
     name: "{{ truenas_hostname }}"
 
+- name: Get current system general settings
+  ansible.builtin.command:
+    cmd: midclt call system.general.config
+  register: system_general_current
+  changed_when: false
+
 - name: Configure system general settings
   ansible.builtin.command:
     cmd: >-
       midclt call system.general.update
       '{{ system_general_payload | to_json }}'
   vars:
+    current: "{{ system_general_current.stdout | from_json }}"
     system_general_payload:
       timezone: "{{ truenas_timezone }}"
       ui_httpsredirect: true
-  register: system_general_result
-  changed_when: system_general_result.rc == 0
+  when: >-
+    current.timezone != truenas_timezone or
+    current.ui_httpsredirect != true
+  changed_when: true
+
+- name: Get current DNS configuration
+  ansible.builtin.command:
+    cmd: midclt call network.configuration.config
+  register: dns_current
+  changed_when: false
 
 - name: Configure DNS
   ansible.builtin.command:
@@ -21,9 +36,13 @@
       midclt call network.configuration.update
       '{{ dns_payload | to_json }}'
   vars:
+    current: "{{ dns_current.stdout | from_json }}"
     dns_payload:
       hostname: "{{ truenas_hostname }}"
       domain: "{{ truenas_domain }}"
       nameserver1: "{{ truenas_nameserver }}"
-  register: dns_result
-  changed_when: dns_result.rc == 0
+  when: >-
+    current.hostname != truenas_hostname or
+    current.domain != truenas_domain or
+    current.nameserver1 != truenas_nameserver
+  changed_when: true

--- a/ansible/playbooks/tasks/system.yaml
+++ b/ansible/playbooks/tasks/system.yaml
@@ -24,7 +24,9 @@
       current.timezone != truenas_timezone or
       current.ui_httpsredirect != true
     )
+  register: system_general_result
   changed_when: true
+  failed_when: system_general_result.rc != 0 or 'error' in (system_general_result.stderr | default(''))
 
 - name: Get current DNS configuration
   ansible.builtin.command:
@@ -49,4 +51,6 @@
       current.domain != truenas_domain or
       current.nameserver1 != truenas_nameserver
     )
+  register: dns_result
   changed_when: true
+  failed_when: dns_result.rc != 0 or 'error' in (dns_result.stderr | default(''))

--- a/ansible/playbooks/tasks/ups.yaml
+++ b/ansible/playbooks/tasks/ups.yaml
@@ -1,0 +1,32 @@
+---
+# UPS is not covered by arensb.truenas — use midclt (ADR-0013)
+
+- name: Get current UPS configuration
+  ansible.builtin.command:
+    cmd: midclt call ups.config
+  register: ups_current
+  changed_when: false
+
+- name: Configure UPS
+  ansible.builtin.command:
+    cmd: >-
+      midclt call ups.update
+      '{{ ups_payload | to_json }}'
+  vars:
+    ups_payload:
+      mode: "{{ truenas_ups.mode }}"
+      identifier: "{{ truenas_ups.identifier }}"
+      driver: "{{ truenas_ups.driver }}"
+      port: "{{ truenas_ups.port }}"
+      shutdown: "{{ truenas_ups.shutdown }}"
+      shutdowntimer: "{{ truenas_ups.shutdowntimer }}"
+      monuser: "{{ truenas_ups.monuser }}"
+      monpwd: "{{ truenas_secrets.secrets.ups_monpwd }}"
+      powerdown: "{{ truenas_ups.powerdown }}"
+      hostsync: "{{ truenas_ups.hostsync }}"
+  no_log: true
+  register: ups_result
+  changed_when: >-
+    (ups_current.stdout | from_json).mode != truenas_ups.mode or
+    (ups_current.stdout | from_json).identifier != truenas_ups.identifier or
+    (ups_current.stdout | from_json).driver != truenas_ups.driver

--- a/ansible/playbooks/tasks/ups.yaml
+++ b/ansible/playbooks/tasks/ups.yaml
@@ -44,3 +44,4 @@
     )
   register: ups_result
   changed_when: true
+  failed_when: ups_result.rc != 0 or 'error' in (ups_result.stderr | default(''))

--- a/ansible/playbooks/tasks/ups.yaml
+++ b/ansible/playbooks/tasks/ups.yaml
@@ -1,5 +1,5 @@
 ---
-# UPS is not covered by arensb.truenas — use midclt (ADR-0013)
+# UPS is not covered by arensb.truenas — use midclt (ADR-0017)
 
 - name: Get current UPS configuration
   ansible.builtin.command:
@@ -26,7 +26,11 @@
       powerdown: "{{ truenas_ups.powerdown }}"
       hostsync: "{{ truenas_ups.hostsync }}"
   no_log: true
+  # Note: monpwd is always sent but cannot be compared — TrueNAS does not
+  # return the current password in ups.config. To force a password update,
+  # change any other field or run with -e ups_force_update=true.
   when: >-
+    (ups_force_update | default(false)) or
     current.mode != truenas_ups.mode or
     current.identifier != truenas_ups.identifier or
     current.driver != truenas_ups.driver or

--- a/ansible/playbooks/tasks/ups.yaml
+++ b/ansible/playbooks/tasks/ups.yaml
@@ -30,6 +30,7 @@
   # return the current password in ups.config. To force a password update,
   # change any other field or run with -e ups_force_update=true.
   when: >-
+    not ansible_check_mode and (
     (ups_force_update | default(false)) or
     current.mode != truenas_ups.mode or
     current.identifier != truenas_ups.identifier or
@@ -40,5 +41,6 @@
     current.monuser != truenas_ups.monuser or
     current.powerdown != truenas_ups.powerdown or
     current.hostsync != truenas_ups.hostsync
+    )
   register: ups_result
   changed_when: true

--- a/ansible/playbooks/tasks/ups.yaml
+++ b/ansible/playbooks/tasks/ups.yaml
@@ -13,6 +13,7 @@
       midclt call ups.update
       '{{ ups_payload | to_json }}'
   vars:
+    current: "{{ ups_current.stdout | from_json }}"
     ups_payload:
       mode: "{{ truenas_ups.mode }}"
       identifier: "{{ truenas_ups.identifier }}"
@@ -25,8 +26,15 @@
       powerdown: "{{ truenas_ups.powerdown }}"
       hostsync: "{{ truenas_ups.hostsync }}"
   no_log: true
+  when: >-
+    current.mode != truenas_ups.mode or
+    current.identifier != truenas_ups.identifier or
+    current.driver != truenas_ups.driver or
+    current.port != truenas_ups.port or
+    current.shutdown != truenas_ups.shutdown or
+    current.shutdowntimer != truenas_ups.shutdowntimer or
+    current.monuser != truenas_ups.monuser or
+    current.powerdown != truenas_ups.powerdown or
+    current.hostsync != truenas_ups.hostsync
   register: ups_result
-  changed_when: >-
-    (ups_current.stdout | from_json).mode != truenas_ups.mode or
-    (ups_current.stdout | from_json).identifier != truenas_ups.identifier or
-    (ups_current.stdout | from_json).driver != truenas_ups.driver
+  changed_when: true

--- a/ansible/playbooks/tasks/users.yaml
+++ b/ansible/playbooks/tasks/users.yaml
@@ -1,0 +1,18 @@
+---
+- name: Manage users
+  arensb.truenas.user:
+    name: "{{ item.name }}"
+    uid: "{{ item.uid }}"
+    group: "{{ item.group }}"
+    comment: "{{ item.full_name }}"
+    email: "{{ item.email | default(omit) }}"
+    home: "{{ item.home }}"
+    shell: "{{ item.shell | default('/usr/sbin/nologin') }}"
+    smb: "{{ item.smb | default(false) }}"
+    password: "{{ truenas_secrets.secrets.user_passwords[item.name] }}"
+    password_disabled: "{{ item.password_disabled | default(false) }}"
+    state: present
+  loop: "{{ truenas_users }}"
+  loop_control:
+    label: "{{ item.name }}"
+  no_log: true

--- a/ansible/playbooks/truenas.yaml
+++ b/ansible/playbooks/truenas.yaml
@@ -11,7 +11,8 @@
     - name: Load SOPS-encrypted secrets
       ansible.builtin.set_fact:
         truenas_secrets: >-
-          {{ lookup('community.sops.sops', 'ansible/inventory/host_vars/'
+          {{ lookup('community.sops.sops',
+             inventory_dir + '/host_vars/'
              + inventory_hostname + '/secrets.sops.yaml')
              | from_yaml }}
       delegate_to: localhost

--- a/ansible/playbooks/truenas.yaml
+++ b/ansible/playbooks/truenas.yaml
@@ -4,9 +4,72 @@
   gather_facts: false
   collections:
     - arensb.truenas
+  environment:
+    middleware_method: client
 
-  tasks: []
-  # TODO: Add TrueNAS configuration tasks
-  #   - Datasets
-  #   - SMB/NFS shares
-  #   - Services
+  tasks:
+    - name: Load SOPS-encrypted secrets
+      ansible.builtin.set_fact:
+        truenas_secrets: >-
+          {{ lookup('community.sops.sops', 'ansible/inventory/host_vars/'
+             + inventory_hostname + '/secrets.sops.yaml')
+             | from_yaml }}
+      delegate_to: localhost
+      become: false
+      no_log: true
+
+    - name: System configuration
+      ansible.builtin.include_tasks: tasks/system.yaml
+      tags: [system]
+
+    - name: Certificate management
+      ansible.builtin.include_tasks: tasks/certificates.yaml
+      tags: [certificates]
+
+    - name: Groups
+      ansible.builtin.include_tasks: tasks/groups.yaml
+      tags: [users, groups]
+
+    - name: Users
+      ansible.builtin.include_tasks: tasks/users.yaml
+      tags: [users]
+
+    - name: ZFS datasets
+      ansible.builtin.include_tasks: tasks/datasets.yaml
+      tags: [datasets]
+
+    - name: SMB shares
+      ansible.builtin.include_tasks: tasks/sharing_smb.yaml
+      tags: [shares, smb]
+
+    - name: NFS shares
+      ansible.builtin.include_tasks: tasks/sharing_nfs.yaml
+      tags: [shares, nfs]
+
+    - name: NFS service configuration
+      ansible.builtin.include_tasks: tasks/nfs.yaml
+      tags: [services, nfs]
+
+    - name: Services
+      ansible.builtin.include_tasks: tasks/services.yaml
+      tags: [services]
+
+    - name: Scrub tasks
+      ansible.builtin.include_tasks: tasks/scrub.yaml
+      tags: [scrub]
+
+    - name: UPS configuration
+      ansible.builtin.include_tasks: tasks/ups.yaml
+      tags: [ups]
+
+    - name: Cloud sync
+      ansible.builtin.include_tasks: tasks/cloud_sync.yaml
+      tags: [cloud_sync]
+
+    - name: Docker configuration
+      ansible.builtin.include_tasks: tasks/docker.yaml
+      tags: [docker]
+
+    - name: Network configuration
+      ansible.builtin.include_tasks: tasks/network.yaml
+      tags: [network]

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,3 +1,5 @@
 collections:
   - name: arensb.truenas
     version: "1.14.4"
+  - name: community.sops
+    version: "1.9.2"

--- a/docs/decisions/0016-ansible-variable-structure.md
+++ b/docs/decisions/0016-ansible-variable-structure.md
@@ -52,7 +52,8 @@ This means the file structure remains readable — only values under keys named 
 ### Confirmation
 
 `sops -d ansible/inventory/host_vars/truenas.home.molier.net/secrets.sops.yaml` decrypts successfully.
-Ansible playbook loads both files automatically from `host_vars/`.
+Ansible auto-loads the plaintext `vars.yaml` file from `host_vars/`.
+The `secrets.sops.yaml` file is explicitly decrypted at runtime via the `community.sops.sops` lookup and stored under `truenas_secrets`.
 
 ## Pros and Cons of the Options
 

--- a/docs/decisions/0016-ansible-variable-structure.md
+++ b/docs/decisions/0016-ansible-variable-structure.md
@@ -1,0 +1,88 @@
+---
+status: accepted
+date: 2026-04-06
+decision-makers: Remko Molier
+---
+
+# Use plaintext YAML with SOPS encrypted secrets for Ansible variables
+
+## Context and Problem Statement
+
+Ansible needs host-specific configuration to manage TrueNAS SCALE.
+This includes both non-sensitive values (hostnames, paths, share names, schedules) and secrets (passwords, API tokens, cloud credentials).
+How should these variables be structured and stored?
+
+## Decision Drivers
+
+- Must integrate with the existing SOPS-based secrets workflow (ADR-0009)
+- Non-secret configuration should be readable in diffs without decryption
+- Should match the pattern already established for OpenTofu variables
+- Must support the `community.sops` Ansible collection for runtime decryption
+
+## Considered Options
+
+- Plaintext YAML + SOPS-encrypted secrets file with `encrypted_regex`
+- Single SOPS-encrypted file for all variables
+- Ansible Vault for secrets
+
+## Decision Outcome
+
+Chosen option: "Plaintext YAML + SOPS-encrypted secrets file with `encrypted_regex`", because it mirrors the OpenTofu pattern (`terraform.tfvars.sops.json` with `encrypted_regex: "^secrets$"`), keeps non-secret values reviewable in plain text, and reuses the existing SOPS + GPG infrastructure.
+
+### Structure
+
+```text
+ansible/inventory/host_vars/truenas.home.molier.net/
+  vars.yaml              Plaintext configuration
+  secrets.sops.yaml      SOPS-encrypted, only "secrets" keys encrypted
+```
+
+The `secrets.sops.yaml` file uses the existing `.sops.yaml` creation rule that matches `*.sops.yaml` with `encrypted_regex: "^secrets$"`.
+This means the file structure remains readable — only values under keys named `secrets` are encrypted.
+
+### Consequences
+
+- Good, because non-secret config (IPs, paths, share names) is readable without GPG access
+- Good, because diffs of `secrets.sops.yaml` show which secret keys changed, even if values are opaque
+- Good, because the same `.sops.yaml` rules and GPG key cover both OpenTofu and Ansible
+- Good, because `community.sops` lookup plugin decrypts at runtime without manual steps
+- Bad, because two files per host adds mild complexity vs. a single file
+- Neutral, because the pattern scales to additional hosts if needed
+
+### Confirmation
+
+`sops -d ansible/inventory/host_vars/truenas.home.molier.net/secrets.sops.yaml` decrypts successfully.
+Ansible playbook loads both files automatically from `host_vars/`.
+
+## Pros and Cons of the Options
+
+### Plaintext YAML + SOPS-encrypted secrets
+
+Split variables into two files: plain `vars.yaml` and SOPS-encrypted `secrets.sops.yaml`.
+
+- Good, because matches the existing OpenTofu variable pattern
+- Good, because non-secret values are always readable
+- Good, because reuses existing `.sops.yaml` creation rules
+- Bad, because requires `community.sops` collection as an Ansible dependency
+
+### Single SOPS-encrypted file
+
+All variables (including non-secrets) in one SOPS-encrypted file.
+
+- Good, because single source of truth per host
+- Bad, because non-secret values (paths, share names) require GPG to read
+- Bad, because diffs are less useful when everything is encrypted
+
+### Ansible Vault
+
+Use Ansible's built-in vault encryption for secrets.
+
+- Good, because no additional tooling — built into Ansible
+- Bad, because introduces a second encryption system alongside SOPS
+- Bad, because vault-encrypted files are fully opaque (no selective encryption)
+- Bad, because vault passwords must be managed separately from GPG keys
+
+## More Information
+
+- [ADR-0009](0009-use-sops-for-secrets-management.md) — SOPS as the secrets management tool
+- [community.sops collection](https://github.com/ansible-collections/community.sops) — Ansible SOPS integration

--- a/docs/decisions/0017-use-midclt-for-uncovered-truenas-areas.md
+++ b/docs/decisions/0017-use-midclt-for-uncovered-truenas-areas.md
@@ -1,0 +1,88 @@
+---
+status: accepted
+date: 2026-04-06
+decision-makers: Remko Molier
+---
+
+# Use midclt for TrueNAS configuration areas not covered by arensb.truenas
+
+## Context and Problem Statement
+
+The `arensb.truenas` Ansible collection provides 18 modules for TrueNAS SCALE, but several configuration areas have no corresponding module: UPS, cloud sync, network interfaces, Docker/app config, GUI certificate assignment, and system settings like timezone and NTP.
+How should these gaps be filled?
+
+## Decision Drivers
+
+- The uncovered areas are stable, rarely-changed configuration
+- Maintaining custom Ansible modules adds ongoing development burden
+- The `midclt` CLI is TrueNAS's official tool for interacting with middlewared
+- The `arensb.truenas` collection already connects via SSH, so `midclt` is available on the target
+
+## Considered Options
+
+- Raw `midclt call` tasks via `ansible.builtin.command`
+- Custom Ansible modules wrapping the TrueNAS Python API client
+- Wait for upstream collection to add modules
+
+## Decision Outcome
+
+Chosen option: "Raw `midclt call` tasks", because these configuration areas change infrequently, the `midclt` CLI is stable and well-documented, and building custom modules would add maintenance overhead disproportionate to the benefit.
+
+### Pattern
+
+Each `midclt` task should follow this pattern for idempotency:
+
+1. Query the current state with `midclt call <service>.config` or `<service>.query`
+2. Compare with desired state
+3. Only call `<service>.update` or `<service>.create` when changes are needed
+4. Use `changed_when` and `failed_when` to report correct status
+
+### Consequences
+
+- Good, because no custom code to maintain — uses TrueNAS's own CLI
+- Good, because covers 100% of the TrueNAS API surface
+- Good, because can be implemented immediately without waiting for upstream
+- Bad, because `midclt` tasks lack the declarative feel of native Ansible modules
+- Bad, because idempotency must be implemented manually per task
+- Neutral, because if `arensb.truenas` adds modules later, tasks can be migrated incrementally
+
+### Confirmation
+
+`midclt` tasks produce correct `changed`/`ok` status when run twice in a row.
+Tasks with `changed_when: false` do not report spurious changes.
+
+## Pros and Cons of the Options
+
+### Raw midclt call tasks
+
+Use `ansible.builtin.command` to run `midclt call` on the TrueNAS host.
+
+- Good, because zero additional code or dependencies
+- Good, because `midclt` is the same tool the TrueNAS UI uses internally
+- Good, because any TrueNAS API endpoint is accessible
+- Bad, because manual idempotency logic per task
+- Bad, because no automatic `--check` / `--diff` mode support
+
+### Custom Ansible modules
+
+Write Python modules using the `truenas_api_client` library.
+
+- Good, because full Ansible integration (check mode, diff, idempotency)
+- Good, because cleaner playbook syntax
+- Bad, because significant development and testing effort
+- Bad, because must track TrueNAS API changes across versions
+- Bad, because disproportionate to the frequency of changes in these areas
+
+### Wait for upstream
+
+Wait for `arensb.truenas` to add modules for missing areas.
+
+- Good, because no work required
+- Bad, because no timeline — open PRs for UPS (#52) and apps (#32) have been pending for months
+- Bad, because blocks automation for these areas indefinitely
+
+## More Information
+
+- [ADR-0008](0008-split-tooling-opentofu-and-ansible.md) — Ansible chosen for TrueNAS management
+- [arensb/ansible-truenas](https://github.com/arensb/ansible-truenas) — the collection and its module coverage
+- [TrueNAS midclt documentation](https://www.truenas.com/docs/scale/25.10/api/) — API reference

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,3 +32,5 @@ Skip trivial or easily reversible choices.
 | [ADR-0013](0013-use-gitleaks-for-secret-scanning.md) | Use gitleaks for secret scanning | accepted | 2026-04-06 |
 | [ADR-0014](0014-manage-github-repo-settings-with-opentofu.md) | Manage GitHub repo settings with OpenTofu | accepted | 2026-04-06 |
 | [ADR-0015](0015-use-renovate-for-dependency-updates.md) | Use Renovate for automated dependency updates | accepted | 2026-04-06 |
+| [ADR-0016](0016-ansible-variable-structure.md) | Use plaintext YAML with SOPS encrypted secrets for Ansible | accepted | 2026-04-06 |
+| [ADR-0017](0017-use-midclt-for-uncovered-truenas-areas.md) | Use midclt for uncovered TrueNAS configuration areas | accepted | 2026-04-06 |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -32,3 +32,4 @@ When you use a runbook, update this date and add post-incident notes if applicab
 | [Terraform state recovery](terraform-state-recovery.md) | Recovery | Critical | Remko Molier | 2026-04-04 |
 | [Horaco switch setup](horaco-switch-setup.md) | Operations | Medium | Remko Molier | 2026-04-05 |
 | [Rotate age key for SOPS](rotate-age-key.md) | Operations | High | Remko Molier | 2026-04-06 |
+| [TrueNAS Ansible bootstrap](truenas-ansible-bootstrap.md) | Onboarding | Medium | Remko Molier | 2026-04-06 |

--- a/docs/runbooks/truenas-ansible-bootstrap.md
+++ b/docs/runbooks/truenas-ansible-bootstrap.md
@@ -66,7 +66,7 @@ ssh truenas_admin@172.16.1.2 'sudo midclt call system.info' | python3 -m json.to
 ```
 
 Expected result: JSON with system info (hostname, version, uptime).
-If this requires a password, add `truenas_admin` to passwordless sudo or set `ansible_become_password` in the SOPS secrets file.
+If this requires a password, either configure passwordless sudo for `truenas_admin`, or provide the become password interactively when running Ansible (`ansible-playbook --ask-become-pass ...`).
 
 ### 4. Install Ansible collections
 

--- a/docs/runbooks/truenas-ansible-bootstrap.md
+++ b/docs/runbooks/truenas-ansible-bootstrap.md
@@ -1,0 +1,125 @@
+---
+title: "TrueNAS Ansible bootstrap"
+owner: "Remko Molier"
+last-verified: "2026-04-06"
+severity: "medium"
+related: []
+---
+
+# TrueNAS Ansible bootstrap
+
+## Overview
+
+One-time setup to enable Ansible management of TrueNAS SCALE.
+The `arensb.truenas` collection connects via SSH and runs `midclt` on the host, so SSH key authentication must be configured before the playbook can run.
+
+## Symptoms
+
+- `ansible-playbook` fails with `Permission denied (publickey,password)`
+- First-time TrueNAS setup — Ansible has never managed this host
+
+## Prerequisites
+
+- [ ] TrueNAS SCALE is installed and accessible on `172.16.1.2`
+- [ ] SSH service is enabled in TrueNAS (System > Services > SSH)
+- [ ] The `truenas_admin` user exists (created during TrueNAS installation)
+- [ ] You have an SSH key pair on your workstation (`~/.ssh/id_ed25519` or similar)
+- [ ] `mise install` has been run to install `ansible-core`
+- [ ] Ansible collections are installed: `ansible-galaxy collection install -r ansible/requirements.yaml`
+
+## Diagnosis
+
+1. Test SSH connectivity — expected result: password prompt (not "connection refused")
+
+   ```bash
+   ssh truenas_admin@172.16.1.2
+   ```
+
+2. Verify Ansible can reach the host — expected result: pong (after password prompt)
+
+   ```bash
+   ansible truenas -i ansible/inventory/hosts.yaml -m ping --ask-pass
+   ```
+
+## Resolution
+
+### 1. Copy SSH public key to TrueNAS
+
+```bash
+ssh-copy-id truenas_admin@172.16.1.2
+```
+
+Enter the `truenas_admin` password when prompted.
+
+### 2. Verify key-based authentication
+
+```bash
+ssh truenas_admin@172.16.1.2 'echo "SSH key auth works"'
+```
+
+Expected result: prints the message without asking for a password.
+
+### 3. Verify sudo/become access
+
+```bash
+ssh truenas_admin@172.16.1.2 'sudo midclt call system.info' | python3 -m json.tool
+```
+
+Expected result: JSON with system info (hostname, version, uptime).
+If this requires a password, add `truenas_admin` to passwordless sudo or set `ansible_become_password` in the SOPS secrets file.
+
+### 4. Install Ansible collections
+
+```bash
+ansible-galaxy collection install -r ansible/requirements.yaml
+```
+
+### 5. Encrypt the secrets file
+
+Edit `ansible/inventory/host_vars/truenas.home.molier.net/secrets.sops.yaml` with real credentials, then encrypt:
+
+```bash
+sops -e -i ansible/inventory/host_vars/truenas.home.molier.net/secrets.sops.yaml
+```
+
+### 6. Test the playbook in check mode
+
+```bash
+cd /home/remko/Development/RemkoMolier/homelab
+ansible-playbook ansible/playbooks/truenas.yaml -i ansible/inventory/hosts.yaml --check --diff
+```
+
+Expected result: tasks show what would change, no errors.
+
+### 7. Run the playbook
+
+```bash
+ansible-playbook ansible/playbooks/truenas.yaml -i ansible/inventory/hosts.yaml
+```
+
+Run specific sections with tags:
+
+```bash
+ansible-playbook ansible/playbooks/truenas.yaml -i ansible/inventory/hosts.yaml --tags users
+ansible-playbook ansible/playbooks/truenas.yaml -i ansible/inventory/hosts.yaml --tags shares
+```
+
+## Rollback
+
+SSH key auth is additive — it does not disable password auth.
+To remove the SSH key:
+
+1. SSH to TrueNAS with password: `ssh truenas_admin@172.16.1.2`
+2. Edit authorized keys: `nano ~/.ssh/authorized_keys`
+3. Remove the relevant key line
+
+## Escalation
+
+- If SSH is unreachable, check the TrueNAS web UI at `https://172.16.1.2` to verify the SSH service is running and bound to `enp6s0`
+- If `midclt` commands fail, check TrueNAS version compatibility with the `arensb.truenas` collection version
+- Console access via IPMI or physical keyboard is the last resort if SSH and web UI are both unreachable
+
+## Post-incident notes
+
+| Date | Notes |
+| ------ | ------- |

--- a/docs/runbooks/truenas-ansible-bootstrap.md
+++ b/docs/runbooks/truenas-ansible-bootstrap.md
@@ -62,11 +62,12 @@ Expected result: prints the message without asking for a password.
 ### 3. Verify sudo/become access
 
 ```bash
-ssh truenas_admin@172.16.1.2 'sudo midclt call system.info' | python3 -m json.tool
+ssh truenas_admin@172.16.1.2 'sudo -n midclt call system.info'
 ```
 
 Expected result: JSON with system info (hostname, version, uptime).
-If this requires a password, either configure passwordless sudo for `truenas_admin`, or provide the become password interactively when running Ansible (`ansible-playbook --ask-become-pass ...`).
+If it fails with "sudo: a password is required", passwordless sudo is not configured.
+Either configure passwordless sudo for `truenas_admin`, or provide the become password interactively when running Ansible (`ansible-playbook --ask-become-pass ...`).
 
 ### 4. Install Ansible collections
 

--- a/docs/runbooks/truenas-ansible-bootstrap.md
+++ b/docs/runbooks/truenas-ansible-bootstrap.md
@@ -85,7 +85,7 @@ sops -e -i ansible/inventory/host_vars/truenas.home.molier.net/secrets.sops.yaml
 ### 6. Test the playbook in check mode
 
 ```bash
-cd /home/remko/Development/RemkoMolier/homelab
+# From the repo root
 ansible-playbook ansible/playbooks/truenas.yaml -i ansible/inventory/hosts.yaml --check --diff
 ```
 


### PR DESCRIPTION
## Summary

- Add Ansible playbook and task files to manage TrueNAS SCALE configuration as code
- Covers: system settings, TLS certificates, users/groups, ZFS datasets, SMB/NFS shares, services, scrub tasks, UPS, cloud sync, Docker, and network interfaces
- Uses `arensb.truenas` collection for covered areas, raw `midclt` calls for gaps (UPS, cloud sync, network, Docker)
- Add ADR-0016 (Ansible variable structure: plaintext YAML + SOPS `encrypted_regex`) and ADR-0017 (midclt for uncovered areas)
- Add bootstrap runbook for SSH key setup and first playbook run
- Add `/review` skill for comprehensive code review
- Configuration extracted from TrueNAS 25.10.1 config export

## Before merging

- [ ] Bootstrap SSH key auth to TrueNAS ([runbook](docs/runbooks/truenas-ansible-bootstrap.md))
- [ ] Fill in real secrets in `secrets.sops.yaml` and encrypt with `sops -e -i`
- [ ] Issue TLS certificate for TrueNAS from intermediate CA
- [ ] Install collections: `ansible-galaxy collection install -r ansible/requirements.yaml`
- [ ] Test with `--check --diff` before applying

## Test plan

- [x] Verify `ansible-playbook --syntax-check ansible/playbooks/truenas.yaml` passes
- [ ] Run with `--check --diff` against live TrueNAS to validate no unexpected changes
- [ ] Apply incrementally with `--tags system`, `--tags users`, `--tags shares`, etc.
- [ ] Apply network last with console access ready (`--tags network`)